### PR TITLE
Adding java compiler version to maven pom.xml 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,14 @@
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>1.5</source>
+          <target>1.5</target>
+        </configuration>
+      </plugin>
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Needed to fix compilation error on Linux (mvn was using default 1.3 version).